### PR TITLE
Fixup: Remedy build errors and enable server-side settings changes as UID 1000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 /x/
 local.properties
 /scrcpy-server
+.vscode/

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -117,11 +117,11 @@ _scrcpy() {
             return
             ;;
         --orientation|--display-orientation)
-            COMPREPLY=($(compgen -> '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
+            COMPREPLY=($(compgen -W '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
             return
             ;;
         --record-orientation)
-            COMPREPLY=($(compgen -> '0 90 180 270' -- "$cur"))
+            COMPREPLY=($(compgen -W '0 90 180 270' -- "$cur"))
             return
             ;;
         --lock-video-orientation)

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -116,8 +116,7 @@ _scrcpy() {
             COMPREPLY=($(compgen -W 'front back external' -- "$cur"))
             return
             ;;
-        --orientation
-        --display-orientation)
+        --orientation|--display-orientation)
             COMPREPLY=($(compgen -> '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
             return
             ;;

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -642,7 +642,11 @@ Enable/disable FPS counter (print frames/second in logs)
 
 .TP
 .B Ctrl+click-and-move
-Pinch-to-zoom from the center of the screen
+Pinch-to-zoom and rotate from the center of the screen
+
+.TP
+.B Shift+click-and-move
+Tilt (slide vertically with two fingers)
 
 .TP
 .B Drag & drop APK file

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -124,7 +124,7 @@ Use USB device (if there is exactly one, like adb -d).
 Also see \fB\-e\fR (\fB\-\-select\-tcpip\fR).
 
 .TP
-.BI "\-\-disable-screensaver"
+.BI "\-\-disable\-screensaver"
 Disable screensaver while scrcpy is running.
 
 .TP

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2360,6 +2360,7 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_CAMERA_HIGH_SPEED:
                 opts->camera_high_speed = true;
+                break;
             case OPT_ROOT:
                 opts->root = true;
                 break;

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -953,7 +953,11 @@ static const struct sc_shortcut shortcuts[] = {
     },
     {
         .shortcuts = { "Ctrl+click-and-move" },
-        .text = "Pinch-to-zoom from the center of the screen",
+        .text = "Pinch-to-zoom and rotate from the center of the screen",
+    },
+    {
+        .shortcuts = { "Shift+click-and-move" },
+        .text = "Tilt (slide vertically with two fingers)",
     },
     {
         .shortcuts = { "Drag & drop APK file" },

--- a/app/src/common.h
+++ b/app/src/common.h
@@ -1,6 +1,7 @@
 #ifndef SC_COMMON_H
 #define SC_COMMON_H
 
+#include "config.h"
 #include "compat.h"
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))

--- a/app/src/common.h
+++ b/app/src/common.h
@@ -1,7 +1,6 @@
 #ifndef SC_COMMON_H
 #define SC_COMMON_H
 
-#include "config.h"
 #include "compat.h"
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -5,6 +5,7 @@
 #include <libavformat/version.h>
 #include <libavutil/version.h>
 #include <SDL2/SDL_version.h>
+#include "config.h"
 
 #ifndef __WIN32
 # define PRIu64_ PRIu64

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -1,8 +1,6 @@
 #ifndef SC_COMPAT_H
 #define SC_COMPAT_H
 
-#include "config.h"
-
 #include <libavcodec/version.h>
 #include <libavformat/version.h>
 #include <libavutil/version.h>

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -32,6 +32,8 @@ struct sc_input_manager {
     } sdl_shortcut_mods;
 
     bool vfinger_down;
+    bool vfinger_invert_x;
+    bool vfinger_invert_y;
 
     // Tracks the number of identical consecutive shortcut key down events.
     // Not to be confused with event->repeat, which counts the number of

--- a/doc/control.md
+++ b/doc/control.md
@@ -85,7 +85,7 @@ way as <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>).
 To disable automatic clipboard synchronization, use
 `--no-clipboard-autosync`.
 
-## Pinch-to-zoom
+## Pinch-to-zoom, rotate and tilt simulation
 
 To simulate "pinch-to-zoom": <kbd>Ctrl</kbd>+_click-and-move_.
 
@@ -93,8 +93,12 @@ More precisely, hold down <kbd>Ctrl</kbd> while pressing the left-click button.
 Until the left-click button is released, all mouse movements scale and rotate
 the content (if supported by the app) relative to the center of the screen.
 
+To simulate a tilt gesture: <kbd>Shift</kbd>+_click-and-move-up-or-down_.
+
 Technically, _scrcpy_ generates additional touch events from a "virtual finger"
-at a location inverted through the center of the screen.
+at a location inverted through the center of the screen. When pressing
+<kbd>Ctrl</kbd> the x and y coordinates are inverted. Using <kbd>Shift</kbd>
+only inverts x.
 
 
 ## Key repeat

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -49,7 +49,8 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Synchronize clipboards and paste⁵           | <kbd>MOD</kbd>+<kbd>v</kbd>
  | Inject computer clipboard text              | <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>
  | Enable/disable FPS counter (on stdout)      | <kbd>MOD</kbd>+<kbd>i</kbd>
- | Pinch-to-zoom                               | <kbd>Ctrl</kbd>+_click-and-move_
+ | Pinch-to-zoom/rotate                        | <kbd>Ctrl</kbd>+_click-and-move_
+ | Tilt (slide vertically with 2 fingers)      | <kbd>Shift</kbd>+_click-and-move_
  | Drag & drop APK file                        | Install APK from computer
  | Drag & drop non-APK file                    | [Push file to device](control.md#push-file-to-device)
 

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
@@ -6,6 +6,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
 import android.view.Surface;
+import android.system.Os;
 
 public class ScreenCapture extends SurfaceCapture implements Device.RotationListener, Device.FoldListener {
 

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
@@ -74,7 +74,7 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         // On Android 12 preview, SDK_INT is still R (not S), but CODENAME is "S".
         boolean secure = Build.VERSION.SDK_INT < Build.VERSION_CODES.R || (Build.VERSION.SDK_INT == Build.VERSION_CODES.R && !"S"
                 .equals(Build.VERSION.CODENAME));
-        if (Os.getuid() < 2000) {
+        if (Os.getuid() == 1000 || Os.getuid() == 1003) {
             secure = true;
         }
         return SurfaceControl.createDisplay("scrcpy", secure);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -2,7 +2,7 @@ package com.genymobile.scrcpy;
 
 import android.os.BatteryManager;
 import android.os.Build;
-
+import android.system.Os;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ClipboardManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ClipboardManager.java
@@ -45,7 +45,8 @@ public final class ClipboardManager {
                                 getPrimaryClipMethod = manager.getClass().getMethod("getPrimaryClip", String.class, int.class, String.class);
                                 getMethodVersion = 3;
                             } catch (NoSuchMethodException e4) {
-                                getPrimaryClipMethod = manager.getClass().getMethod("getPrimaryClip", String.class, String.class, int.class, int.class, boolean.class);
+                                getPrimaryClipMethod = manager.getClass()
+                                        .getMethod("getPrimaryClip", String.class, String.class, int.class, int.class, boolean.class);
                                 getMethodVersion = 4;
                             }
                         }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ClipboardManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ClipboardManager.java
@@ -96,7 +96,7 @@ public final class ClipboardManager {
                 return (ClipData) method.invoke(manager, FakeContext.PACKAGE_NAME, FakeContext.ROOT_UID, null);
             default:
                 // The last boolean parameter is "userOperate"
-                return (ClipData) method.invoke(manager, FakeContext.FakeContext.PACKAGE_NAME, null, FakeContext.ROOT_UID, 0, true);
+                return (ClipData) method.invoke(manager, FakeContext.PACKAGE_NAME, null, FakeContext.ROOT_UID, 0, true);
         }
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -133,7 +133,6 @@ public final class ServiceManager {
                 throw new AssertionError(e);
             }
         }
-
         return activityManager;
     }
 


### PR DESCRIPTION
This pull request addresses several issues. There were a few hiccups along the way with me not understanding the Meson build system (removing the ```config.h``` reference from 2 other ```*.h``` files and then re-adding them is the main example), as well as ensuring that my personal VS Code environment did not add itself to the repository. Another thing it addresses is the fact that there were a few errors that caused the program not to build in the first place, and also an implicit fallthrough warning that was resolved. The final change made was to actually properly check for which users have the ability to grant a secure display (currently I know of UIDs ```1000``` and ```1003```, respectively ```AID_SYSTEM``` and ```AID_GRAPHICS```. I still have the UID in use set to ```AID_SYSTEM``` for ease of use.